### PR TITLE
Gitlab permissions for the access token needs updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .DS_Store
+repopack-output.txt
+main.exe

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A tool to transfer your GitLab commit history to GitHub, reflecting your GitLab 
 ## Overview
 This tool fetches your commit history from private GitLab repositories and imports it into a specified GitHub repository, creating a visual representation of your activity on GitHub’s contribution graph. It can be configured for automated daily imports or manual runs.
 
-## Features 
+## Features
 -	Automated Daily Imports: Syncs your GitLab activity with GitHub automatically each day.
 -	Manual Imports: Allows on-demand updates.
 -	Secure Data Handling: Requires minimal permissions and uses GitHub repository secrets for configuration.
@@ -68,7 +68,7 @@ This project uses GitHub Actions to automate builds and daily synchronization:
 - Secrets Configuration: The secrets allow secure storage and retrieval of required tokens and URLs during automation.
 
 ### Important Notes:
-- **GitLab permissions:** The tool only requires read access to your GitLab repositories.
+- **GitLab permissions:** The tool requires read-only access to your GitLab user and Gitlab repositories (`read_user` and `read_repository`)
 - **GitHub permissions:** Your GitHub token must have write access to the destination repository for automatic pushes.
 
 ## License


### PR DESCRIPTION
The access token for Gitlab should include both `read_repository` and `read_user` permissions. I was getting HTTP 403 error in the `GetGitlabUser` function without this.

Also, because I ran this locally, I added `main.exe` and `repopack-output.txt` to the .gitignore. But I don't know how this may impact your Github Action workflow for release build so do let me know and I can remove them.

Thank you for this tool. Once I got over the HTTP 403 error, it worked great!